### PR TITLE
Bugfix/fix encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6320,6 +6320,11 @@
         "require-main-filename": "^2.0.0"
       }
     },
+    "text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "prettier": "^1.18.2"
+  },
+  "dependencies": {
+    "text-encoding": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffered-text-reader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Extract text file's content in a buffered approach ",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { TextDecoder } from "text-encoding";
+
 export default class BufferedReader {
   constructor(file) {
     this._file = file;
@@ -23,14 +25,14 @@ export default class BufferedReader {
 
     if (err) throw err;
 
-    const chunk = this._parse(buffer, delimiter);
+    const [chunk, tail] = this._parse(buffer, delimiter);
 
     const bytesRead = chunk.length;
-    this._updateCursor(bytesRead);
+    this._updateCursor(bytesRead, tail != null);
 
     // if we found the expected delimiter
-    if (chunk.charAt(chunk.length - 1) === delimiter) {
-      return memo + chunk.slice(0, -1);
+    if (tail != null) {
+      return memo + chunk;
     }
 
     // if reached EOF
@@ -72,19 +74,10 @@ export default class BufferedReader {
   };
 
   _parse = (buffer, delimiter) => {
-    let output = "";
-    const delimiterCode = delimiter.charCodeAt(0);
-
-    buffer.some(code => {
-      output += String.fromCharCode(code);
-
-      return code === delimiterCode;
-    });
-
-    return output;
+    return new TextDecoder().decode(buffer).split(delimiter);
   };
 
-  _updateCursor(chunkSize) {
-    this._cursor += chunkSize;
+  _updateCursor(chunkSize, skipSeparator) {
+    this._cursor += chunkSize + (skipSeparator ? 1 : 0);
   }
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -10,14 +10,13 @@ test("Empty line ending file", async () => {
 });
 
 test("Reads consecutive lines", async () => {
-  const expected = "lorem ipsum";
-  const file = new File([`foo bar\n${expected}`], "f.txt");
+  const lineOne = "lorem ipsum";
+  const lineTwo = "dolor sit amet";
+  const file = new File([`${lineOne}\n${lineTwo}`], "f.txt");
   const bufferedReader = new BufferedReader(file);
 
-  await bufferedReader.readLine(); // discard first line
-  const got = await bufferedReader.readLine();
-
-  expect(got).toEqual(expected);
+  expect(await bufferedReader.readLine()).toEqual(lineOne);
+  expect(await bufferedReader.readLine()).toEqual(lineTwo);
 });
 
 test("Reaches EOL", async () => {
@@ -39,7 +38,7 @@ test("Non empty line ending file", async () => {
   expect(got).toEqual(line);
 });
 
-test("Throws an error when expected smaller line lenght", async () => {
+test("Throws an error when expected smaller line length", async () => {
   const longLine = "foo".repeat(100);
   const file = new File([longLine], "f.txt");
   const bufferedReader = new BufferedReader(file);
@@ -52,4 +51,13 @@ test("Throws an error when providing invalid chunk size", async () => {
   const bufferedReader = new BufferedReader(file);
 
   await expect(bufferedReader.readLine(0)).rejects.toThrow();
+});
+
+test("Parses latin content", async () => {
+  const expected = "áàãç";
+  const file = new File([expected], "f.txt");
+  const bufferedReader = new BufferedReader(file);
+  const got = await bufferedReader.readLine();
+
+  expect(got).toEqual(expected);
 });


### PR DESCRIPTION
Improves encoding support by using browser native's textdecoder (also included as a polyfill). An use case example can be found at the very last test spec.